### PR TITLE
Move content length limit before JSON body parsing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,15 +71,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Define the POST route for elevations
     let post_elevation_route = warp::path::end()
         .and(warp::post())
-        .and(warp::body::json::<LatLngs>())
         .and(warp::body::content_length_limit(max_post_size.as_u64()))
+        .and(warp::body::json::<LatLngs>())
         .and(tileset_filter.clone())
         .and(config_filter.clone())
         .and_then(post_elevations)
         .or(warp::path("api")
             .and(warp::post())
-            .and(warp::body::json::<LatLngs>())
             .and(warp::body::content_length_limit(max_post_size.as_u64()))
+            .and(warp::body::json::<LatLngs>())
             .and(tileset_filter.clone())
             .and(config_filter.clone())
             .and_then(post_elevations));


### PR DESCRIPTION
## Summary
- enforce max POST size before parsing JSON payload

## Testing
- `cargo fmt --all -- --check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6891b5765950832fa40e4eeae95090be